### PR TITLE
Revamp authentication modal layout

### DIFF
--- a/components/AuthView.tsx
+++ b/components/AuthView.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import type { User } from "../types";
 import { authService } from "../src/services/authService";
-import { XCircleIcon, LoadingSpinner, GoogleIcon, FacebookIcon } from "./icons";
+import { XCircleIcon, LoadingSpinner, GoogleIcon } from "./icons";
 
 interface AuthViewProps {
     onClose: () => void;
@@ -9,24 +9,17 @@ interface AuthViewProps {
     onSetAuthLoading: (isLoading: boolean) => void;
 }
 
-const SocialButton: React.FC<{ provider: "google" | "facebook"; onClick: () => void; disabled: boolean }> = ({ provider, onClick, disabled }) => {
-    const isGoogle = provider === "google";
-    const styles = isGoogle
-        ? "bg-white text-ink-700 border border-ink-200 hover:bg-white/80"
-        : "bg-[#1877F2] text-white border border-transparent hover:bg-[#166eeb]";
-
-    return (
-        <button
-            type="button"
-            onClick={onClick}
-            disabled={disabled}
-            className={`pill-button w-full justify-center ${styles} disabled:opacity-60`}
-        >
-            {isGoogle ? <GoogleIcon className="h-5 w-5" /> : <FacebookIcon className="h-6 w-6" />}
-            Continue with {isGoogle ? "Google" : "Facebook"}
-        </button>
-    );
-};
+const GoogleButton: React.FC<{ onClick: () => void; disabled: boolean }> = ({ onClick, disabled }) => (
+    <button
+        type="button"
+        onClick={onClick}
+        disabled={disabled}
+        className="pill-button auth-google-button disabled:opacity-60"
+    >
+        <GoogleIcon className="h-5 w-5" />
+        Continue with Google
+    </button>
+);
 
 export const AuthView: React.FC<AuthViewProps> = ({ onClose, onLoginSuccess, onSetAuthLoading }) => {
     const [mode, setMode] = useState<"login" | "signup">("login");
@@ -36,12 +29,12 @@ export const AuthView: React.FC<AuthViewProps> = ({ onClose, onLoginSuccess, onS
     const [error, setError] = useState("");
     const [isLoading, setIsLoading] = useState(false);
 
-    const handleSocialLogin = async (provider: "google" | "facebook") => {
+    const handleGoogleLogin = async () => {
         setError("");
         setIsLoading(true);
         onSetAuthLoading(true);
         try {
-            const user = await authService.socialLogIn(provider);
+            const user = await authService.socialLogIn("google");
             onLoginSuccess(user);
         } catch (err: any) {
             setError(err.message || "An error occurred during social login.");
@@ -77,79 +70,109 @@ export const AuthView: React.FC<AuthViewProps> = ({ onClose, onLoginSuccess, onS
 
     return (
         <div className="modal-backdrop" onClick={onClose}>
-            <div className="modal-surface" onClick={event => event.stopPropagation()}>
-                <button onClick={onClose} className="absolute right-6 top-6 text-ink-400 transition hover:text-ink-600" aria-label="Close authentication">
+            <div className="modal-surface auth-modal" onClick={event => event.stopPropagation()}>
+                <button onClick={onClose} className="auth-close-button" aria-label="Close authentication">
                     <XCircleIcon className="h-7 w-7" />
                 </button>
-                <div className="space-y-6">
-                    <div className="space-y-2 text-center">
-                        <span className="section-heading text-ink-400">{mode === "login" ? "Welcome back" : "Join Woon"}</span>
-                        <h2 className="text-heading text-2xl">{mode === "login" ? "Log in to continue" : "Create an account"}</h2>
-                        <p className="text-sm text-ink-500">
-                            {mode === "login" ? "Pick up where you left off and keep celebrating." : "Share your celebrations with the neighborhood."}
-                        </p>
+                <div className="auth-modal__grid">
+                    <div className="auth-modal__hero">
+                        <div className="auth-modal__hero-content">
+                            <span className="auth-modal__badge">Your neighborhood, celebrated</span>
+                            <h2>Celebrate every milestone together</h2>
+                            <p>Sign in to follow events, share stories, and stay close to what matters around you.</p>
+                            <ul className="auth-modal__points">
+                                <li>✨ Save gatherings to revisit later</li>
+                                <li>🎉 Share your own celebrations in seconds</li>
+                                <li>🤝 Connect with neighbors cheering alongside you</li>
+                            </ul>
+                        </div>
                     </div>
 
-                    <div className="space-y-3">
-                        <SocialButton provider="google" onClick={() => handleSocialLogin("google")} disabled={isLoading} />
-                        <SocialButton provider="facebook" onClick={() => handleSocialLogin("facebook")} disabled={isLoading} />
-                    </div>
+                    <div className="auth-modal__form">
+                        <div className="auth-modal__header">
+                            <span className="section-heading text-ink-400">{mode === "login" ? "Welcome back" : "Join Woon"}</span>
+                            <h3>{mode === "login" ? "Log in to continue" : "Create your Woon account"}</h3>
+                            <p className="auth-modal__description">
+                                {mode === "login"
+                                    ? "Pick up where you left off and keep the celebrations going."
+                                    : "Add your voice to the neighborhood and start sharing in moments that matter."}
+                            </p>
+                        </div>
 
-                    <div className="flex items-center gap-4 text-xs uppercase text-ink-400">
-                        <div className="h-px flex-1 bg-ink-200" />
-                        <span>or continue with email</span>
-                        <div className="h-px flex-1 bg-ink-200" />
-                    </div>
+                        <div className="auth-modal__social">
+                            <GoogleButton onClick={handleGoogleLogin} disabled={isLoading} />
+                            <div className="auth-modal__divider">
+                                <span>or use your email</span>
+                            </div>
+                        </div>
 
-                    <form onSubmit={handleSubmit} className="space-y-3">
-                        {mode === "signup" && (
-                            <input
-                                type="text"
-                                value={name}
-                                onChange={(e) => setName(e.target.value)}
-                                placeholder="Your name"
-                                required
-                                disabled={isLoading}
-                                className="w-full rounded-xl border border-transparent bg-white/85 px-4 py-3 text-sm text-ink-800 placeholder:text-ink-400 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-60"
-                            />
-                        )}
-                        <input
-                            type="email"
-                            value={email}
-                            onChange={(e) => setEmail(e.target.value)}
-                            placeholder="Email address"
-                            required
-                            disabled={isLoading}
-                            className="w-full rounded-xl border border-transparent bg-white/85 px-4 py-3 text-sm text-ink-800 placeholder:text-ink-400 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-60"
-                        />
-                        <input
-                            type="password"
-                            value={password}
-                            onChange={(e) => setPassword(e.target.value)}
-                            placeholder="Password"
-                            required
-                            disabled={isLoading}
-                            className="w-full rounded-xl border border-transparent bg-white/85 px-4 py-3 text-sm text-ink-800 placeholder:text-ink-400 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-60"
-                        />
-
-                        {error && <p className="text-sm font-medium text-red-500">{error}</p>}
-
-                        <button type="submit" disabled={isLoading} className="pill-button pill-accent w-full justify-center">
-                            {isLoading ? (
-                                <>
-                                    <LoadingSpinner className="h-5 w-5" />
-                                    Processing...
-                                </>
-                            ) : (
-                                mode === "login" ? "Log in" : "Sign up"
+                        <form onSubmit={handleSubmit} className="auth-form">
+                            {mode === "signup" && (
+                                <div className="auth-input-group">
+                                    <label htmlFor="auth-name">Full name</label>
+                                    <input
+                                        id="auth-name"
+                                        type="text"
+                                        value={name}
+                                        onChange={(e) => setName(e.target.value)}
+                                        placeholder="Your name"
+                                        required
+                                        disabled={isLoading}
+                                        className="auth-input"
+                                    />
+                                </div>
                             )}
-                        </button>
-                    </form>
+                            <div className="auth-input-group">
+                                <label htmlFor="auth-email">Email address</label>
+                                <input
+                                    id="auth-email"
+                                    type="email"
+                                    value={email}
+                                    onChange={(e) => setEmail(e.target.value)}
+                                    placeholder="you@example.com"
+                                    required
+                                    disabled={isLoading}
+                                    className="auth-input"
+                                />
+                            </div>
+                            <div className="auth-input-group">
+                                <label htmlFor="auth-password">Password</label>
+                                <input
+                                    id="auth-password"
+                                    type="password"
+                                    value={password}
+                                    onChange={(e) => setPassword(e.target.value)}
+                                    placeholder="Minimum 6 characters"
+                                    required
+                                    disabled={isLoading}
+                                    className="auth-input"
+                                />
+                            </div>
 
-                    <div className="text-center text-sm text-ink-500">
-                        <button onClick={toggleMode} className="font-semibold text-primary underline-offset-4 transition hover:underline">
-                            {mode === "login" ? "Don't have an account? Sign up" : "Already have an account? Log in"}
-                        </button>
+                            {error && <p className="auth-error">{error}</p>}
+
+                            <button type="submit" disabled={isLoading} className="pill-button pill-accent auth-submit">
+                                {isLoading ? (
+                                    <>
+                                        <LoadingSpinner className="h-5 w-5" />
+                                        Processing...
+                                    </>
+                                ) : (
+                                    mode === "login" ? "Log in" : "Sign up"
+                                )}
+                            </button>
+                        </form>
+
+                        <div className="auth-toggle">
+                            <span>{mode === "login" ? "Don't have an account?" : "Already have an account?"}</span>
+                            <button onClick={toggleMode} type="button">{mode === "login" ? "Sign up" : "Log in"}</button>
+                        </div>
+
+                        {mode === "signup" && (
+                            <p className="auth-legal">
+                                By signing up, you agree to our Terms of Service and Privacy Policy.
+                            </p>
+                        )}
                     </div>
                 </div>
             </div>

--- a/src/components/AuthView.tsx
+++ b/src/components/AuthView.tsx
@@ -1,34 +1,26 @@
 import React, { useState } from "react"
 import { useAuth } from "../contexts/AuthContext"
-import { XCircleIcon, LoadingSpinner, GoogleIcon, FacebookIcon } from "../../components/icons"
+import { XCircleIcon, LoadingSpinner, GoogleIcon } from "../../components/icons"
 
 interface AuthViewProps {
     onClose: () => void
     prompt?: string
 }
 
-const SocialButton: React.FC<{
-    provider: "google" | "facebook"
+const GoogleButton: React.FC<{
     onClick: () => void
     disabled: boolean
-}> = ({ provider, onClick, disabled }) => {
-    const isGoogle = provider === "google"
-    const styles = isGoogle
-        ? "bg-white text-ink-700 border border-ink-200 hover:bg-white/80"
-        : "bg-blue-600 text-white border border-transparent hover:bg-blue-700"
-
-    return (
-        <button
-            type="button"
-            onClick={onClick}
-            disabled={disabled}
-            className={`pill-button w-full justify-center ${styles} disabled:opacity-60`}
-        >
-            {isGoogle ? <GoogleIcon className="h-5 w-5" /> : <FacebookIcon className="h-5 w-5" />}
-            Continue with {isGoogle ? "Google" : "Facebook"}
-        </button>
-    )
-}
+}> = ({ onClick, disabled }) => (
+    <button
+        type="button"
+        onClick={onClick}
+        disabled={disabled}
+        className="pill-button auth-google-button disabled:opacity-60"
+    >
+        <GoogleIcon className="h-5 w-5" />
+        Continue with Google
+    </button>
+)
 
 export default function AuthView({ onClose, prompt }: AuthViewProps) {
     const { signUp, logIn, socialLogIn } = useAuth()
@@ -39,11 +31,11 @@ export default function AuthView({ onClose, prompt }: AuthViewProps) {
     const [error, setError] = useState("")
     const [isLoading, setIsLoading] = useState(false)
 
-    const handleSocialLogin = async (provider: "google" | "facebook") => {
+    const handleGoogleLogin = async () => {
         setError("")
         setIsLoading(true)
         try {
-            await socialLogIn(provider)
+            await socialLogIn("google")
             // For OAuth, user will be redirected - don't close modal here
             // The auth state change will handle the modal closure
         } catch (err: any) {
@@ -106,122 +98,132 @@ export default function AuthView({ onClose, prompt }: AuthViewProps) {
 
     return (
         <div className="modal-backdrop" onClick={onClose}>
-            <div className="modal-surface" onClick={event => event.stopPropagation()}>
+            <div className="modal-surface auth-modal" onClick={event => event.stopPropagation()}>
                 <button
                     onClick={onClose}
-                    className="absolute right-6 top-6 text-ink-400 transition hover:text-ink-600"
+                    className="auth-close-button"
                     aria-label="Close authentication"
                 >
                     <XCircleIcon className="h-7 w-7" />
                 </button>
-                <div className="space-y-6">
-                    <div className="space-y-2 text-center">
-                        {prompt && (
-                            <p className="text-sm font-medium text-primary">{prompt}</p>
-                        )}
-                        <span className="section-heading text-ink-400">
-                            {mode === "login" ? "Welcome back" : "Join Woon"}
-                        </span>
-                        <h2 className="text-heading text-2xl">
-                            {mode === "login" ? "Log in to continue" : "Create an account"}
-                        </h2>
-                        <p className="text-sm text-ink-500">
-                            {mode === "login"
-                                ? "Pick up where you left off and keep celebrating."
-                                : "Share your celebrations with the neighborhood."}
-                        </p>
+
+                <div className="auth-modal__grid">
+                    <div className="auth-modal__hero">
+                        <div className="auth-modal__hero-content">
+                            <span className="auth-modal__badge">Your neighborhood, celebrated</span>
+                            <h2>Celebrate every milestone together</h2>
+                            <p>
+                                Sign in to follow events, share stories, and stay close to what matters
+                                around you.
+                            </p>
+                            <ul className="auth-modal__points">
+                                <li>✨ Save gatherings to revisit later</li>
+                                <li>🎉 Share your own celebrations in seconds</li>
+                                <li>🤝 Connect with neighbors cheering alongside you</li>
+                            </ul>
+                        </div>
                     </div>
 
-                    {/* Social login enabled - ensure OAuth providers are configured in Supabase */}
-                    {true && (
-                        <>
-                            <div className="space-y-3">
-                                <SocialButton
-                                    provider="google"
-                                    onClick={() => handleSocialLogin("google")}
-                                    disabled={isLoading}
-                                />
-                                <SocialButton
-                                    provider="facebook"
-                                    onClick={() => handleSocialLogin("facebook")}
-                                    disabled={isLoading}
-                                />
+                    <div className="auth-modal__form">
+                        <div className="auth-modal__header">
+                            {prompt && <p className="auth-modal__prompt">{prompt}</p>}
+                            <span className="section-heading text-ink-400">
+                                {mode === "login" ? "Welcome back" : "Join Woon"}
+                            </span>
+                            <h3>{mode === "login" ? "Log in to continue" : "Create your Woon account"}</h3>
+                            <p className="auth-modal__description">
+                                {mode === "login"
+                                    ? "Pick up where you left off and keep the celebrations going."
+                                    : "Add your voice to the neighborhood and start sharing in moments that matter."}
+                            </p>
+                        </div>
+
+                        <div className="auth-modal__social">
+                            <GoogleButton onClick={handleGoogleLogin} disabled={isLoading} />
+                            <div className="auth-modal__divider">
+                                <span>or use your email</span>
                             </div>
+                        </div>
 
-                            <div className="flex items-center gap-4 text-xs uppercase text-ink-400">
-                                <div className="h-px flex-1 bg-ink-200" />
-                                <span>or continue with email</span>
-                                <div className="h-px flex-1 bg-ink-200" />
-                            </div>
-                        </>
-                    )}
-
-                    <form onSubmit={handleSubmit} className="space-y-3">
-                        {mode === "signup" && (
-                            <input
-                                type="text"
-                                value={name}
-                                onChange={(e) => setName(e.target.value)}
-                                placeholder="Your name"
-                                required
-                                disabled={isLoading}
-                                className="w-full rounded-xl border border-transparent bg-white/85 px-4 py-3 text-sm text-ink-800 placeholder:text-ink-400 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-60"
-                            />
-                        )}
-                        <input
-                            type="email"
-                            value={email}
-                            onChange={(e) => setEmail(e.target.value)}
-                            placeholder="Email address"
-                            required
-                            disabled={isLoading}
-                            className="w-full rounded-xl border border-transparent bg-white/85 px-4 py-3 text-sm text-ink-800 placeholder:text-ink-400 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-60"
-                        />
-                        <input
-                            type="password"
-                            value={password}
-                            onChange={(e) => setPassword(e.target.value)}
-                            placeholder="Password"
-                            required
-                            disabled={isLoading}
-                            minLength={6}
-                            className="w-full rounded-xl border border-transparent bg-white/85 px-4 py-3 text-sm text-ink-800 placeholder:text-ink-400 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-60"
-                        />
-
-                        {error && <p className="text-sm font-medium text-red-500">{error}</p>}
-
-                        <button
-                            type="submit"
-                            disabled={isLoading}
-                            className="pill-button pill-accent w-full justify-center"
-                        >
-                            {isLoading ? (
-                                <>
-                                    <LoadingSpinner className="h-5 w-5" />
-                                    Processing...
-                                </>
-                            ) : (
-                                mode === "login" ? "Log in" : "Sign up"
+                        <form onSubmit={handleSubmit} className="auth-form">
+                            {mode === "signup" && (
+                                <div className="auth-input-group">
+                                    <label htmlFor="auth-name">Full name</label>
+                                    <input
+                                        id="auth-name"
+                                        type="text"
+                                        value={name}
+                                        onChange={(e) => setName(e.target.value)}
+                                        placeholder="Your name"
+                                        required
+                                        disabled={isLoading}
+                                        className="auth-input"
+                                    />
+                                </div>
                             )}
-                        </button>
-                    </form>
+                            <div className="auth-input-group">
+                                <label htmlFor="auth-email">Email address</label>
+                                <input
+                                    id="auth-email"
+                                    type="email"
+                                    value={email}
+                                    onChange={(e) => setEmail(e.target.value)}
+                                    placeholder="you@example.com"
+                                    required
+                                    disabled={isLoading}
+                                    className="auth-input"
+                                />
+                            </div>
+                            <div className="auth-input-group">
+                                <label htmlFor="auth-password">Password</label>
+                                <input
+                                    id="auth-password"
+                                    type="password"
+                                    value={password}
+                                    onChange={(e) => setPassword(e.target.value)}
+                                    placeholder="Minimum 6 characters"
+                                    required
+                                    disabled={isLoading}
+                                    minLength={6}
+                                    className="auth-input"
+                                />
+                            </div>
 
-                    <div className="text-center text-sm text-ink-500">
-                        <button
-                            onClick={toggleMode}
-                            className="font-semibold text-primary underline-offset-4 transition hover:underline"
-                        >
-                            {mode === "login"
-                                ? "Don't have an account? Sign up"
-                                : "Already have an account? Log in"}
-                        </button>
+                            {error && <p className="auth-error">{error}</p>}
+
+                            <button
+                                type="submit"
+                                disabled={isLoading}
+                                className="pill-button pill-accent auth-submit"
+                            >
+                                {isLoading ? (
+                                    <>
+                                        <LoadingSpinner className="h-5 w-5" />
+                                        Processing...
+                                    </>
+                                ) : (
+                                    mode === "login" ? "Log in" : "Sign up"
+                                )}
+                            </button>
+                        </form>
+
+                        <div className="auth-toggle">
+                            <span>
+                                {mode === "login"
+                                    ? "Don't have an account?"
+                                    : "Already have an account?"}
+                            </span>
+                            <button onClick={toggleMode} type="button">
+                                {mode === "login" ? "Sign up" : "Log in"}
+                            </button>
+                        </div>
+
+                        {mode === "signup" && (
+                            <p className="auth-legal">
+                                By signing up, you agree to our Terms of Service and Privacy Policy.
+                            </p>
+                        )}
                     </div>
-
-                    {mode === "signup" && (
-                        <p className="text-xs text-ink-400 text-center">
-                            By signing up, you agree to our Terms of Service and Privacy Policy
-                        </p>
-                    )}
                 </div>
             </div>
         </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -154,6 +154,261 @@ body::before {
   width: min(480px, 90vw);
 }
 
+.auth-modal {
+  padding: 0;
+  width: min(860px, 92vw);
+  overflow: hidden;
+  position: relative;
+}
+
+.auth-close-button {
+  position: absolute;
+  top: 1.35rem;
+  right: 1.35rem;
+  border: 0;
+  background: transparent;
+  color: var(--ink-400);
+  display: inline-flex;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.auth-close-button:hover,
+.auth-close-button:focus {
+  color: var(--ink-700);
+}
+
+.auth-modal__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+}
+
+.auth-modal__hero {
+  position: relative;
+  padding: 3.25rem 2.5rem 2.75rem;
+  background: linear-gradient(135deg, rgba(81, 68, 211, 0.92), rgba(244, 123, 37, 0.9));
+  color: rgba(255, 255, 255, 0.95);
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-start;
+}
+
+.auth-modal__hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 15% 20%, rgba(255, 255, 255, 0.38), transparent 55%),
+              radial-gradient(circle at 85% 30%, rgba(255, 255, 255, 0.22), transparent 60%);
+  opacity: 0.85;
+}
+
+.auth-modal__hero-content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.auth-modal__hero h2 {
+  font-size: 1.75rem;
+  line-height: 1.2;
+  margin: 0;
+  font-weight: 700;
+}
+
+.auth-modal__hero p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.88);
+}
+
+.auth-modal__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  padding: 0.35rem 0.9rem;
+  border-radius: var(--radius-pill);
+  background: rgba(255, 255, 255, 0.18);
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.auth-modal__points {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.45rem;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.auth-modal__form {
+  background: var(--surface-strong);
+  padding: 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.auth-modal__header h3 {
+  margin: 0.4rem 0 0;
+  font-size: 1.5rem;
+  line-height: 1.3;
+  color: var(--ink-900);
+}
+
+.auth-modal__prompt {
+  margin: 0 0 0.35rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--accent-strong);
+}
+
+.auth-modal__description {
+  margin: 0.75rem 0 0;
+  font-size: 0.95rem;
+  color: var(--ink-500);
+  line-height: 1.6;
+}
+
+.auth-modal__social {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.auth-google-button {
+  width: 100%;
+  justify-content: center;
+  background: white;
+  color: var(--ink-700);
+  border: 1px solid var(--ink-200);
+}
+
+.auth-google-button:hover {
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.auth-modal__divider {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-300);
+}
+
+.auth-modal__divider::before,
+.auth-modal__divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--ink-200);
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.auth-input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.auth-input-group label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--ink-700);
+}
+
+.auth-input {
+  width: 100%;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(53, 38, 29, 0.12);
+  background: rgba(255, 255, 255, 0.92);
+  padding: 0.85rem 1rem;
+  font-size: 0.95rem;
+  color: var(--ink-800);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.auth-input:focus {
+  outline: none;
+  border-color: rgba(244, 123, 37, 0.55);
+  box-shadow: 0 0 0 3px rgba(244, 123, 37, 0.18);
+}
+
+.auth-error {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #ef4444;
+}
+
+.auth-submit {
+  width: 100%;
+  justify-content: center;
+  font-size: 1rem;
+  min-height: 3rem;
+}
+
+.auth-toggle {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: var(--ink-500);
+}
+
+.auth-toggle button {
+  border: 0;
+  background: transparent;
+  font-weight: 700;
+  color: var(--accent-strong);
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 4px;
+}
+
+.auth-toggle button:hover {
+  color: var(--accent);
+}
+
+.auth-legal {
+  margin: -0.35rem 0 0;
+  font-size: 0.75rem;
+  text-align: center;
+  color: var(--ink-400);
+}
+
+@media (min-width: 768px) {
+  .auth-modal__grid {
+      grid-template-columns: 1.1fr 1fr;
+  }
+
+  .auth-modal__hero {
+      padding: 3.75rem 3rem;
+      min-height: 100%;
+  }
+
+  .auth-modal__form {
+      padding: 3rem;
+  }
+}
+
 .bottom-sheet {
   backdrop-filter: saturate(140%) blur(34px);
   background: rgba(255, 255, 254, 0.94);


### PR DESCRIPTION
## Summary
- redesign the authentication modal with a split hero + form layout and clearer copy
- remove the Facebook social login button, leaving Google and email sign-in paths
- add dedicated styling rules for the refreshed auth modal experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2039e6ac4833388c59c6b46bf9284

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Redesigned authentication modal with a two-panel layout (hero + form).
  - Added Google sign-in button and streamlined social login flow.
  - Introduced mode toggle between Log in and Sign up with contextual copy and legal note.
  - Added inline field validation, clearer error messages, and a loading state on submit.

- Style
  - New responsive styles for the auth modal, inputs, buttons, and dividers; improved labels and focus states.

- Chores
  - Removed Facebook login option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->